### PR TITLE
fix issue with openssl and 32 bit keys

### DIFF
--- a/lib/acts_as_encryptable.rb
+++ b/lib/acts_as_encryptable.rb
@@ -8,7 +8,7 @@ module ActsAsEncryptable
       instance_variable_set(
         encryptor,
         ActiveSupport::MessageEncryptor.new(
-          ActiveSupport::KeyGenerator.new(send key).generate_key(send salt)
+          ActiveSupport::KeyGenerator.new(send key).generate_key(send(salt), 32)
         )
       ) unless instance_variable_defined? encryptor
 
@@ -22,7 +22,7 @@ module ActsAsEncryptable
       instance_variable_set(
         encryptor,
         ActiveSupport::MessageEncryptor.new(
-          ActiveSupport::KeyGenerator.new(send key).generate_key(send salt)
+          ActiveSupport::KeyGenerator.new(send key).generate_key(send(salt), 32)
         )
       ) unless instance_variable_defined? encryptor
 


### PR DESCRIPTION
Looks like something changed with OpenSSL that requires the explicit setting of the key size (to 32?).  I took this from the latest example at: http://api.rubyonrails.org/classes/ActiveSupport/MessageEncryptor.html

Not exactly sure if this is a good assumption but the tests pass again :-)